### PR TITLE
Fix/pandas

### DIFF
--- a/twtools/twstats.py
+++ b/twtools/twstats.py
@@ -113,9 +113,11 @@ def run(tags, time_span, step):
 
             ss.df.drop('start_time', axis=1, inplace=True)  # Drop `start_time`.
             ss.df.drop('end_time', axis=1, inplace=True)  # Drop `end_time`.
+            ss.df.drop('id', axis=1, inplace=True) # Drop `id`.
 
             ss.df = ss.df.groupby(
-                pd.TimeGrouper(step_fmt),
+                #pd.TimeGrouper(step_fmt),
+                pd.Grouper(freq=step_fmt),
                 level=0,
             ).aggregate(
                 np.sum

--- a/twtools/twstats.py
+++ b/twtools/twstats.py
@@ -116,7 +116,6 @@ def run(tags, time_span, step):
             ss.df.drop('id', axis=1, inplace=True) # Drop `id`.
 
             ss.df = ss.df.groupby(
-                #pd.TimeGrouper(step_fmt),
                 pd.Grouper(freq=step_fmt),
                 level=0,
             ).aggregate(


### PR DESCRIPTION
This removes the id column, which appears on the plot if not removed and uses pd.grouper since TimeGrouper was deprecated.